### PR TITLE
Improve mobile layout for hero and portfolio

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1597,9 +1597,10 @@ hr {
 @media (max-width: 575px) {
   .cs_hero.cs_style_2 .cs_happy_client {
     position: absolute;
-    bottom: 5%;
-    right: 12px;
-    left: auto;
+    bottom: 10px;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
     padding: 10px 14px;
     background: #ffffff;
     border-radius: 12px;
@@ -3087,8 +3088,12 @@ hr {
 @media (max-width: 575px) {
   .cs_hero.cs_style_2 .cs_hero_image_box {
     width: 100%;
-    height: initial;
-    padding-bottom: 140%;
+    height: auto;
+    padding-bottom: 100%;
+    left: 0;
+    right: 0;
+    top: auto;
+    position: relative;
   }
 }
 .cs_hero.cs_style_2 .cs_hero_image_box .cs_imagebox_img {
@@ -4204,6 +4209,33 @@ hr {
   }
   .cs_isotop_filter.cs_style1 a {
     padding-bottom: 3px;
+  }
+}
+@media screen and (max-width: 575px) {
+  .cs_isotop.cs_has_gutter_40,
+  .cs_isotop.cs_has_gutter_80,
+  .cs_isotop.cs_has_gutter_100 {
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-bottom: -30px;
+  }
+  .cs_isotop.cs_has_gutter_40 .cs_isotop_item,
+  .cs_isotop.cs_has_gutter_80 .cs_isotop_item,
+  .cs_isotop.cs_has_gutter_100 .cs_isotop_item {
+    padding: 0 15px;
+    margin-bottom: 30px;
+  }
+  .cs_isotop_col_5 .cs_grid_sizer,
+  .cs_isotop_col_5 .cs_isotop_item,
+  .cs_isotop_col_4 .cs_grid_sizer,
+  .cs_isotop_col_4 .cs_isotop_item,
+  .cs_isotop_col_3 .cs_grid_sizer,
+  .cs_isotop_col_3 .cs_isotop_item,
+  .cs_isotop_col_2 .cs_grid_sizer,
+  .cs_isotop_col_2 .cs_isotop_item,
+  .cs_isotop_col_1 .cs_grid_sizer,
+  .cs_isotop_col_1 .cs_isotop_item {
+    width: 100%;
   }
 }
 /*------------------------------------


### PR DESCRIPTION
## Summary
- tweak mobile hero image ratio and center the happy client badge
- add small screen styles for isotop grid

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68613fcc5db8832f88a1d60b551de311